### PR TITLE
fix: nuxt.config.jsでwithCredentialsを設定

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -55,7 +55,8 @@ export default {
   ** See https://axios.nuxtjs.org/options
   */
   axios: {
-    baseURL: 'https://dev.api.twinte.net/v1/'
+    baseURL: 'https://dev.api.twinte.net/v1/',
+    credentials: 'true'
   },
   /*
   ** Build configuration

--- a/pages/mypage/index.vue
+++ b/pages/mypage/index.vue
@@ -30,9 +30,7 @@ export default {
     }
   },
   mounted () {
-    this.$axios.get('/payment/', {
-      withCredentials: true
-    }).then(response => (this.payments = response.data))
+    this.$axios.get('/payment/').then(response => (this.payments = response.data))
   }
 }
 </script>

--- a/pages/mypage/patch.vue
+++ b/pages/mypage/patch.vue
@@ -33,8 +33,6 @@ export default {
       this.$axios.patch('/payment/users/me', {
         nickname: this.nickname,
         link: this.link
-      }, {
-        withCredentials: true
       }
       )
         .then(() => this.$buefy.toast.open({

--- a/pages/mypage/subscription.vue
+++ b/pages/mypage/subscription.vue
@@ -29,17 +29,13 @@ export default {
     }
   },
   mounted () {
-    this.$axios.$get('/payment/subscriptions', {
-      withCredentials: true
-    })
+    this.$axios.$get('/payment/subscriptions')
       .then(response => (this.history = response))
   },
   methods: {
     deletePlan (planId) {
       if (window.confirm('このサブスクリプションを消去しますか？')) {
-        this.$axios.$delete('/payment/subscriptions/' + planId, {
-          withCredentials: true
-        }).then(location.reload())
+        this.$axios.$delete('/payment/subscriptions/' + planId).then(location.reload())
       }
     } }
 }

--- a/pages/onetime.vue
+++ b/pages/onetime.vue
@@ -33,8 +33,7 @@ export default {
       this.$axios.$post('/payment/checkout-session/onetime', {
         amount
       }, {
-        headers: { 'Content-Type': 'application/json' },
-        withCredentials: true
+        headers: { 'Content-Type': 'application/json' }
       }).then((response) => {
         const sessionId = response.sessionId
         stripe.redirectToCheckout({

--- a/pages/register.vue
+++ b/pages/register.vue
@@ -39,8 +39,7 @@ export default {
       this.$axios.$post('https://dev.api.twinte.net/v1/payment/checkout-session/subscription', {
         plan_id: plan
       }, {
-        headers: { 'Content-Type': 'application/json' },
-        withCredentials: true
+        headers: { 'Content-Type': 'application/json' }
       }).then((response) => {
         const sessionId = response.sessionId
         stripe.redirectToCheckout({


### PR DESCRIPTION
## 概要/目的
何回もwithCredentialsを書かなくていいようにする

## やったこと・変更内容
nuxt.config.jsに書いた
各ページの `withCredentials` を消した

## 確認したこと

- [x] 動くことを確認

## 備考

