### PR TITLE
add: 一応動く

### DIFF
--- a/pages/cancel.vue
+++ b/pages/cancel.vue
@@ -1,0 +1,7 @@
+<script>
+export default {
+  mounted () {
+    this.$router.push('/') // /に飛ばす
+  }
+}
+</script>


### PR DESCRIPTION
stripeのページで支払いをキャンセルすると `/cancel` に飛ぶ。
かんたんに `/cancel` にアクセスしたら `/` に飛ばすようにした。
サーバー側で対応できるならそっちのほうがいいかもしれない、ので蹴っても大丈夫なプルリク