### PR TITLE
max-widthを編集

### DIFF
--- a/assets/scss/style.scss
+++ b/assets/scss/style.scss
@@ -4,13 +4,13 @@
 // Set your colors
 $primary: #00c0c0;
 $primary-invert: findColorInvert($primary);
-$twitter: #4099FF;
+$twitter: #4099ff;
 $twitter-invert: findColorInvert($twitter);
 
 // メニューバーの色設定
-$menu-item-active-background-color: #C3EAF7;
-$menu-item-active-color: #1A1D32;
-$menu-item-hover-color:#1A1D32;
+$menu-item-active-background-color: #c3eaf7;
+$menu-item-active-color: #1a1d32;
+$menu-item-hover-color: #1a1d32;
 $menu-item-color: #ffffff;
 $menu-item-radius: 0;
 $menu-list-link-padding: 0.8rem;
@@ -20,55 +20,85 @@ $text: #555555;
 
 // Setup $colors to use as bulma classes (e.g. 'is-twitter')
 $colors: (
-    "white": ($white, $black),
-    "black": ($black, $white),
-    "light": ($light, $light-invert),
-    "dark": ($dark, $dark-invert),
-    "primary": ($primary, $primary-invert),
-    "info": ($info, $info-invert),
-    "success": ($success, $success-invert),
-    "warning": ($warning, $warning-invert),
-    "danger": ($danger, $danger-invert),
-    "twitter": ($twitter, $twitter-invert)
+  "white": (
+    $white,
+    $black
+  ),
+  "black": (
+    $black,
+    $white
+  ),
+  "light": (
+    $light,
+    $light-invert
+  ),
+  "dark": (
+    $dark,
+    $dark-invert
+  ),
+  "primary": (
+    $primary,
+    $primary-invert
+  ),
+  "info": (
+    $info,
+    $info-invert
+  ),
+  "success": (
+    $success,
+    $success-invert
+  ),
+  "warning": (
+    $warning,
+    $warning-invert
+  ),
+  "danger": (
+    $danger,
+    $danger-invert
+  ),
+  "twitter": (
+    $twitter,
+    $twitter-invert
+  )
 );
 
 // Links
 $link: #4c94bd;
-$link-invert: findColorInvert(#4c94bd);;
+$link-invert: findColorInvert(#4c94bd);
 $link-focus-border: #4c94bd;
 
 // Import Bulma and Buefy styles
 @import "~bulma";
 @import "~buefy/src/scss/buefy";
 
-.title{
-    color: #555555;
-    font-style: normal;
-    font-weight: bold;
-    font-size: 23px;
-    line-height: 28px;
-    margin-bottom: 1rem;
+.title {
+  color: #555555;
+  font-style: normal;
+  font-weight: bold;
+  font-size: 23px;
+  line-height: 28px;
+  margin-bottom: 1rem;
 }
 
-.title.pagetitle{
-    border: initial;
+.title.pagetitle {
+  border: initial;
 }
 .title.pagetitle:before {
-    content: '';
-    background-image: url('~assets/Twintelogo-color.png');
-    background-repeat: no-repeat;
-    display: inline-block;
-    height:1.5em;
-    width:1.5em;
-    background-size: contain;
-    vertical-align: middle;
-  }
+  content: "";
+  background-image: url("~assets/Twintelogo-color.png");
+  background-repeat: no-repeat;
+  display: inline-block;
+  height: 1.5em;
+  width: 1.5em;
+  background-size: contain;
+  vertical-align: middle;
+}
 
 // カードを使いやすいように再定義
-.card{
-    background: #FFFFFF;
-    box-shadow: 7px 7px 30px rgba(0, 0, 0, 0.1);
-    border-radius: 15px;
-    padding: 2rem;
-    margin-bottom:2rem;
+.card {
+  background: #ffffff;
+  box-shadow: 7px 7px 30px rgba(0, 0, 0, 0.1);
+  border-radius: 15px;
+  padding: 2rem;
+  margin-bottom: 2rem;
 }

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -188,13 +188,16 @@ $sp: 560px;  // スマホ
 }
 
 .nuxt-contents{
-  max-width: 980px;
+  max-width: 100vh;
   min-height: 100vh;
+  margin:0 40px;
   @include tab {
     width:75vw;
+    margin:0 20px;
   };
   @include sp {
     width:100vw;
+    margin:0;
   };
 }
 

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -14,7 +14,7 @@
     </p>
     <p>当初と比較してユーザー数が増え、それに伴って運営に必要な資金も増えています。</p>
     <div class="has-text-centered">
-      <img src="~/assets/twinte-cost.png" alt="Twin:te_Cost" style="width:100%;">
+      <img src="~/assets/twinte-cost.png" alt="Twin:te_Cost">
     </div>
     <p>
       また、Twin:te バージョン2の開発は現在も続いておりますが、例えばリリースまでに6ヶ月の時間がかかっており、
@@ -64,15 +64,21 @@
 </template>
 
 <script>
-export default {
-}
+export default {};
 </script>
-<style scoped>
-  li{
-    list-style-position: inside;
-    margin: 1rem;
+
+<style  lang="scss" scoped>
+li {
+  list-style-position: inside;
+  margin: 1rem;
+}
+p {
+  margin-bottom: 1rem;
+}
+img {
+  width: 75%;
+  @media (max-width: 560px) {
+    width: 100%;
   }
-  p{
-    margin-bottom: 1rem;
-  }
+}
 </style>


### PR DESCRIPTION
### 概要
- メインコンテンツ部のmax-widthを編集
- ⇧の変更に合わせた画像の調整

### 目的
- 画面幅によってはボタンが横長になりすぎてしまうので、メインコンテンツが横長にならないようにすること（横幅の縦幅に対する比率を設定）

### 備考
 自分のESLintだとTSのセミコロン（確認したのはindex.vue 67行目）でエラーが出ました。環境が原因かもしれないのでスルーしています、ご確認お願いします。