### PR TITLE
ドロワーの追加

### DIFF
--- a/components/MobileHeader.tsx
+++ b/components/MobileHeader.tsx
@@ -2,9 +2,9 @@ import styles from '../styles/components/MobileHeader.module.scss';
 import Link from 'next/link';
 import Drawer from 'react-modern-drawer';
 import 'react-modern-drawer/dist/index.css';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import Sidebar from './Sidebar';
-import { useRouter } from 'next/router';
+import Router from 'next/router';
 
 const MobileHeader: React.FC = () => {
 	const [isDrawerOpen, setIsDrawerOpen] = useState(false);
@@ -13,8 +13,12 @@ const MobileHeader: React.FC = () => {
 	};
 
 	// ドロワーから画面遷移したときに，ドロワーを閉じる
-	const router = useRouter();
-	router.events?.on('routeChangeComplete', () => toggleDrawer());
+	useEffect(() => {
+		Router.events.on('routeChangeStart', toggleDrawer);
+		return () => {
+			Router.events.off('routeChangeStart', toggleDrawer);
+		};
+	}, []);
 
 	return (
 		<header>

--- a/components/MobileHeader.tsx
+++ b/components/MobileHeader.tsx
@@ -4,12 +4,17 @@ import Drawer from 'react-modern-drawer';
 import 'react-modern-drawer/dist/index.css';
 import { useState } from 'react';
 import Sidebar from './Sidebar';
+import { useRouter } from 'next/router';
 
 const MobileHeader: React.FC = () => {
 	const [isDrawerOpen, setIsDrawerOpen] = useState(false);
 	const toggleDrawer = () => {
 		setIsDrawerOpen((prevState) => !prevState);
 	};
+
+	// ドロワーから画面遷移したときに，ドロワーを閉じる
+	const router = useRouter();
+	router.events?.on('routeChangeComplete', () => toggleDrawer());
 
 	return (
 		<header>

--- a/components/MobileHeader.tsx
+++ b/components/MobileHeader.tsx
@@ -8,22 +8,26 @@ import Router from 'next/router';
 
 const MobileHeader: React.FC = () => {
 	const [isDrawerOpen, setIsDrawerOpen] = useState(false);
-	const toggleDrawer = () => {
-		setIsDrawerOpen((prevState) => !prevState);
+	const toggleDrawer = (state: boolean) => {
+		setIsDrawerOpen(() => state);
 	};
 
-	// ドロワーから画面遷移したときに，ドロワーを閉じる
+	// 画面遷移したときに，ドロワーを閉じる
 	useEffect(() => {
-		Router.events.on('routeChangeStart', toggleDrawer);
+		Router.events.on('routeChangeStart', () => {
+			toggleDrawer(false);
+		});
 		return () => {
-			Router.events.off('routeChangeStart', toggleDrawer);
+			Router.events.off('routeChangeStart', () => {
+				toggleDrawer(false);
+			});
 		};
 	}, []);
 
 	return (
 		<header>
 			<div className={styles.navbar}>
-				<button onClick={toggleDrawer} className={`navbar-burger ${styles.navbarBurger}`}>
+				<button onClick={() => toggleDrawer(true)} className={`navbar-burger ${styles.navbarBurger}`}>
 					<span aria-hidden="true"></span>
 					<span aria-hidden="true"></span>
 					<span aria-hidden="true"></span>
@@ -35,7 +39,7 @@ const MobileHeader: React.FC = () => {
 				</div>
 			</div>
 
-			<Drawer open={isDrawerOpen} onClose={toggleDrawer} direction="left">
+			<Drawer open={isDrawerOpen} onClose={() => toggleDrawer(false)} direction="left">
 				<Sidebar />
 			</Drawer>
 		</header>

--- a/components/MobileHeader.tsx
+++ b/components/MobileHeader.tsx
@@ -1,12 +1,34 @@
 import styles from '../styles/components/MobileHeader.module.scss';
 import Link from 'next/link';
+import Drawer from 'react-modern-drawer';
+import 'react-modern-drawer/dist/index.css';
+import { useState } from 'react';
+import Sidebar from './Sidebar';
 
 const MobileHeader: React.FC = () => {
+	const [isDrawerOpen, setIsDrawerOpen] = useState(false);
+	const toggleDrawer = () => {
+		setIsDrawerOpen((prevState) => !prevState);
+	};
+
 	return (
-		<header className={styles.header}>
-			<Link href="/" passHref>
-				<img src="/images/twinte-sponsor-title.png" alt="Twin:te_Logo" />
-			</Link>
+		<header>
+			<div className={styles.navbar}>
+				<button onClick={toggleDrawer} className={`navbar-burger ${styles.navbarBurger}`}>
+					<span aria-hidden="true"></span>
+					<span aria-hidden="true"></span>
+					<span aria-hidden="true"></span>
+				</button>
+				<div className="navbar-brand">
+					<Link href="/" passHref>
+						<img src="/images/twinte-sponsor-title.png" alt="Twin:te_Logo" />
+					</Link>
+				</div>
+			</div>
+
+			<Drawer open={isDrawerOpen} onClose={toggleDrawer} direction="left">
+				<Sidebar />
+			</Drawer>
 		</header>
 	);
 };

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "next": "12.1.4",
     "react": "18.0.0",
     "react-bulma-components": "4.1.0",
-    "react-dom": "18.0.0"
+    "react-dom": "18.0.0",
+    "react-modern-drawer": "^1.1.1"
   },
   "devDependencies": {
     "@types/node": "17.0.23",

--- a/styles/components/MobileHeader.module.scss
+++ b/styles/components/MobileHeader.module.scss
@@ -2,13 +2,18 @@
 
 $sp-header-height: 10vh;
 
-.header {
+.navbar {
     height: $sp-header-height;
     background-color: $menu-color;
+    display: flex;
 
     padding: 1rem;
 
-    img {
-        height: 100%;
+    .navbarBurger {
+        margin-left: 0;
+
+        span {
+            background-color: #ffffff;
+        }
     }
 }

--- a/styles/components/MobileHeader.module.scss
+++ b/styles/components/MobileHeader.module.scss
@@ -1,7 +1,5 @@
 @import "../variables.scss";
 
-$sp-header-height: 10vh;
-
 .navbar {
     height: $sp-header-height;
     background-color: $menu-color;

--- a/styles/variables.scss
+++ b/styles/variables.scss
@@ -3,6 +3,9 @@ $primary: #00c0c0;
 $twitter: #4099ff;
 $twitter-invert: findColorInvert($twitter);
 
+// sp版 ヘッダーの高さ
+$sp-header-height: 10vh;
+
 // メニューバーの色設定
 $menu-color: #1A1D32;
 $menu-item-active-background-color: #c3eaf7;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1592,6 +1592,11 @@ react-is@^16.13.1:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
+react-modern-drawer@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/react-modern-drawer/-/react-modern-drawer-1.1.1.tgz#928bf03337c72294f89eceb39743127863e99f51"
+  integrity sha512-LU79xfQ6f+bINXOie6rUFfU8tFWYjv5zkF03gDVTA9nkECgZZVtTvkata+R0aIbEBI6c/UFdlc/6XLWDOiD1tA==
+
 react@18.0.0:
   version "18.0.0"
   resolved "https://registry.yarnpkg.com/react/-/react-18.0.0.tgz#b468736d1f4a5891f38585ba8e8fb29f91c3cb96"


### PR DESCRIPTION
closes #64 

## やったこと
- react-modern-drawerを用いたドロワーの実装(モバイル版)
  - ドロワーの開くボタンはbulmaのやつを利用
  - 別ページに移動してもドロワーが閉じなかったので，https://github.com/twin-te/twinte-sponsorship/pull/73/commits/00c54c368472ac080e9ccbaac7e2671f5033ba0c のような処理を追加した
    - routerのイベントを監視するんだけど，アプリケーション全体のイベントを監視してしまっている
    - つまりPC版でも toggleDrawer() が呼ばれているが，ドロワーが見えてないので問題ないように見えている
- scss変数は `variables.scss` にまとめたいので移動した．

## 懸念点
- ドロワーの 開く・閉じるのstateを持つのは `MobileHeader.tsx`で問題ないか？