### PR TITLE
モバイル版ヘッダー・ドロワーの修正

### DIFF
--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -46,7 +46,7 @@ export const Layout: React.FC = ({ children }) => {
 			</Head>
 			<div className="columns is-gapless">
 				<div className="column is-hidden-tablet">
-					<MobileHeader />
+					<MobileHeader isLogin={isLogin} handleLogin={handleLogin} handleLogout={handleLogout} />
 				</div>
 				<div className="column is-one-fifth is-hidden-mobile">
 					<Sidebar />
@@ -55,7 +55,7 @@ export const Layout: React.FC = ({ children }) => {
 					<section className="section">
 						<header className={`is-hidden-mobile ${styles.header}`}>
 							<div className="has-text-right">
-								{isLogin == null ? (
+								{isLogin == undefined ? (
 									<Button className="is-primary is-outlined is-loading" />
 								) : (
 									<Button

--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -53,7 +53,7 @@ export const Layout: React.FC = ({ children }) => {
 				</div>
 				<div className="column">
 					<section className="section">
-						<header className={styles.header}>
+						<header className={`is-hidden-mobile ${styles.header}`}>
 							<div className="has-text-right">
 								{isLogin == null ? (
 									<Button className="is-primary is-outlined is-loading" />

--- a/components/MobileHeader.tsx
+++ b/components/MobileHeader.tsx
@@ -7,8 +7,15 @@ import Sidebar from './Sidebar';
 import Router from 'next/router';
 import Image from 'next/image';
 import TwinteLogo from '../public/images/twinte-sponsor-title.png';
+import { Button } from 'react-bulma-components';
 
-const MobileHeader: React.FC = () => {
+type Props = {
+	isLogin: undefined | boolean;
+	handleLogin: () => void;
+	handleLogout: () => void;
+};
+
+const MobileHeader: React.FC<Props> = ({ isLogin, handleLogin, handleLogout }) => {
 	const [isDrawerOpen, setIsDrawerOpen] = useState(false);
 	const toggleDrawer = (state: boolean) => {
 		setIsDrawerOpen(() => state);
@@ -44,6 +51,18 @@ const MobileHeader: React.FC = () => {
 						objectFit="contain"
 					/>
 				</Link>
+				<div className={styles.button}>
+					{isLogin == undefined ? (
+						<Button className="is-ghost is-loading" />
+					) : (
+						<Button
+							className="is-ghost has-text-weight-bold"
+							onClick={() => (isLogin ? handleLogout() : handleLogin())}
+						>
+							{isLogin ? 'ログアウト' : 'ログイン'}
+						</Button>
+					)}
+				</div>
 			</div>
 
 			<Drawer open={isDrawerOpen} onClose={() => toggleDrawer(false)} direction="left">

--- a/components/MobileHeader.tsx
+++ b/components/MobileHeader.tsx
@@ -5,6 +5,8 @@ import 'react-modern-drawer/dist/index.css';
 import { useEffect, useState } from 'react';
 import Sidebar from './Sidebar';
 import Router from 'next/router';
+import Image from 'next/image';
+import TwinteLogo from '../public/images/twinte-sponsor-title.png';
 
 const MobileHeader: React.FC = () => {
 	const [isDrawerOpen, setIsDrawerOpen] = useState(false);
@@ -32,11 +34,16 @@ const MobileHeader: React.FC = () => {
 					<span aria-hidden="true"></span>
 					<span aria-hidden="true"></span>
 				</button>
-				<div className="navbar-brand">
-					<Link href="/" passHref>
-						<img src="/images/twinte-sponsor-title.png" alt="Twin:te_Logo" />
-					</Link>
-				</div>
+				<Link href="/" passHref>
+					<Image
+						src={TwinteLogo}
+						alt="Twin:te_Logo"
+						className={styles.logo}
+						width={100}
+						height={40}
+						objectFit="contain"
+					/>
+				</Link>
 			</div>
 
 			<Drawer open={isDrawerOpen} onClose={() => toggleDrawer(false)} direction="left">

--- a/styles/components/MobileHeader.module.scss
+++ b/styles/components/MobileHeader.module.scss
@@ -8,10 +8,16 @@
     padding: 1rem;
 
     .navbarBurger {
-        margin-left: 0;
+        margin: auto 0;
+        height: 40px;
 
         span {
             background-color: #ffffff;
         }
+    }
+
+    .logo {
+        margin: auto 0;
+
     }
 }

--- a/styles/components/MobileHeader.module.scss
+++ b/styles/components/MobileHeader.module.scss
@@ -18,6 +18,10 @@
 
     .logo {
         margin: auto 0;
+    }
 
+    .button {
+        margin: auto 0;
+        margin-left: auto;
     }
 }

--- a/styles/components/Sidebar.module.scss
+++ b/styles/components/Sidebar.module.scss
@@ -2,6 +2,7 @@
 
 .sidebar {
     height: 100vh;
+    max-width: 250px;
     min-height: 100%;
     padding: 0 1rem;
     background-color: $menu-color;
@@ -12,8 +13,8 @@
     }
 
     .logo {
-        width: 80%;
-        padding-bottom: 1rem;
+        max-width: 200px;
+        padding: 1rem 0.5rem;
     }
 
     a {
@@ -24,7 +25,6 @@
 
     .menuFooter {
         position: fixed;
-        width: 100%;
         bottom: 1rem;
         word-break: break-all;
     }

--- a/styles/components/Sidebar.module.scss
+++ b/styles/components/Sidebar.module.scss
@@ -8,7 +8,7 @@
     background-color: $menu-color;
 
     .menuContent {
-        position: sticky;
+        position: fixed;
         top: 1rem;
     }
 


### PR DESCRIPTION
close #69 
 
## やったこと
- `next/image` 使う
  - #80 のやり残し
- ロゴ画像のサイズ修正
  - #83 のやり残し
- ログイン・ログアウトボタンの追加
  - PC版のログイン・ログアウトボタンは，モバイル版では非表示にした
- ドロワーの中身がスクロールでズレる実装ミスの修正