### PR TITLE
chore: delete 'a' tag color setting

### DIFF
--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -13,7 +13,6 @@ body {
 }
 
 a {
-  color: inherit;
   text-decoration: none;
 }
 


### PR DESCRIPTION
next プロジェクトで最初からあった CSS の設定を残してたので，a タグの色がテキストと同じになっていた．
このPRでは，aタグの余計なCSSを削除した．