### PR TITLE
トースト実装

### DIFF
--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -23,7 +23,6 @@ export const Layout: React.FC = ({ children }) => {
 			cancelButtonText: 'いいえ'
 		});
 		if (result.isConfirmed) {
-			alert('confirm');
 			router.push(getLogoutUrl());
 		}
 	};

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "axios": "^0.26.1",
     "bulma": "^0.9.3",
     "bulma-checkradio": "^2.1.3",
+    "bulma-toast": "^2.4.1",
     "dayjs": "^1.11.1",
     "next": "12.1.4",
     "next-seo": "^5.4.0",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -6,8 +6,13 @@ import * as dayjs from 'dayjs';
 import 'dayjs/locale/ja';
 import { DefaultSeo } from 'next-seo';
 import SEO from '../next-seo.config';
+import * as bulmaToast from 'bulma-toast';
 
 dayjs.locale('ja');
+
+bulmaToast.setDefaults({
+	position: 'top-center'
+});
 
 function MyApp({ Component, pageProps }: AppProps) {
 	return (

--- a/pages/mypage.tsx
+++ b/pages/mypage.tsx
@@ -9,6 +9,7 @@ import { cancelSubscription } from '../api/stripeApi';
 import { useRouter } from 'next/router';
 import { PaymentTypeMap } from '../types/Payment';
 import { NextSeo } from 'next-seo';
+import { toast } from 'bulma-toast';
 
 const MyPage: NextPage = () => {
 	const isLogin = useLoginStatus();
@@ -20,11 +21,18 @@ const MyPage: NextPage = () => {
 	const handleClick = async (id: string) => {
 		try {
 			await cancelSubscription(id);
-			alert('解約に成功しました');
+			toast({
+				message: '解約に成功しました',
+				type: 'is-success'
+			});
+			await new Promise((s) => setTimeout(s, 2000));
 			router.reload();
 		} catch (error) {
 			console.error(error);
-			alert('エラーが発生しました');
+			toast({
+				message: 'エラーが発生しました',
+				type: 'is-danger'
+			});
 		}
 	};
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -610,6 +610,11 @@ bulma-checkradio@^2.1.3:
   dependencies:
     bulma "^0.9.3"
 
+bulma-toast@^2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/bulma-toast/-/bulma-toast-2.4.1.tgz#1e0ea72a810af2cc11a5c39cf4051567f5c29434"
+  integrity sha512-Gwa40dH0gyO3/azJxzFSZD2PKcFlp55HWyPE3gV8gm1WGXyyKrNDCzFlsY8XqxstNRp+xtcdo2L0Y4df+iWNWg==
+
 bulma@^0.9.3:
   version "0.9.3"
   resolved "https://registry.yarnpkg.com/bulma/-/bulma-0.9.3.tgz#ddccb7436ebe3e21bf47afe01d3c43a296b70243"


### PR DESCRIPTION
close #79 

bulma-toast を使って，各種処理をしたあとの情報提示をする．

このPRでは，サブスク解約時のトーストを実装した．サブスク解約後はリロード処理が入るが，トースト表示 -> 2秒待つ -> リロード という処理にした．