### PR TITLE
デザインの修正

### DIFF
--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -1,7 +1,6 @@
 import Head from 'next/head';
 import Sidebar from './Sidebar';
 import MobileHeader from './MobileHeader';
-import styles from '../styles/components/Layout.module.scss';
 import { useLoginStatus } from '../hooks/useLoginStatus';
 import LoginModalContent from './LoginModalContent';
 import { SweetModal } from './SweetAlert';
@@ -51,7 +50,7 @@ export const Layout: React.FC = ({ children }) => {
 				</div>
 				<div className="column">
 					<section className="section">
-						<header className={`is-hidden-mobile ${styles.header}`}>
+						<header className="is-hidden-mobile">
 							<div className="has-text-right">
 								{isLogin == undefined ? (
 									<button className="button is-primary is-outlined is-loading" />
@@ -66,7 +65,7 @@ export const Layout: React.FC = ({ children }) => {
 							</div>
 						</header>
 						<main>{children}</main>
-						<footer className={styles.footer}>
+						<footer className="has-text-centered-mobile has-text-right-tablet mt-6">
 							<a href="https://vercel.com?utm_source=twin-te&utm_campaign=oss">
 								<Image
 									src="https://www.datocms-assets.com/31049/1618983297-powered-by-vercel.svg"

--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -46,7 +46,7 @@ export const Layout: React.FC = ({ children }) => {
 				<div className="column is-hidden-tablet">
 					<MobileHeader isLogin={isLogin} handleLogin={handleLogin} handleLogout={handleLogout} />
 				</div>
-				<div className="column is-one-fifth is-hidden-mobile">
+				<div className="column is-narrow is-hidden-mobile">
 					<Sidebar />
 				</div>
 				<div className="column">

--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -1,4 +1,3 @@
-import Head from 'next/head';
 import Sidebar from './Sidebar';
 import MobileHeader from './MobileHeader';
 import { useLoginStatus } from '../hooks/useLoginStatus';
@@ -37,10 +36,6 @@ export const Layout: React.FC = ({ children }) => {
 
 	return (
 		<>
-			<Head>
-				<link rel="icon" href="/favicon.ico" />
-				<meta name="description" content="Learn how to build a personal website using Next.js" />
-			</Head>
 			<div className="columns is-gapless">
 				<div className="column is-hidden-tablet">
 					<MobileHeader isLogin={isLogin} handleLogin={handleLogin} handleLogout={handleLogout} />

--- a/components/MobileHeader.tsx
+++ b/components/MobileHeader.tsx
@@ -64,7 +64,7 @@ const MobileHeader: React.FC<Props> = ({ isLogin, handleLogin, handleLogout }) =
 				</div>
 			</div>
 
-			<Drawer open={isDrawerOpen} onClose={() => toggleDrawer(false)} direction="left">
+			<Drawer open={isDrawerOpen} onClose={() => toggleDrawer(false)} direction="left" size={200}>
 				<Sidebar />
 			</Drawer>
 		</header>

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -14,7 +14,7 @@ const Sidebar: React.FC = () => {
 				</div>
 				<ul className="menu-list">
 					<li>
-						<Link href="/">寄附のお願い</Link>
+						<Link href="/">寄付のお願い</Link>
 					</li>
 					<li>
 						<Link href="register">寄付・サブスク登録</Link>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -3,6 +3,7 @@ import styles from '../styles/pages/Home.module.scss';
 import TwinteCost from '../public/images/twinte-cost.png';
 import Image from 'next/image';
 import { NextSeo } from 'next-seo';
+import Link from 'next/link';
 
 const Home: NextPage = () => {
 	return (
@@ -75,11 +76,11 @@ const Home: NextPage = () => {
 					メールアドレス等の個人情報の取り扱いについては
 					<a href="https://www.twinte.net/policy/">プライバシーポリシー</a>をご覧ください。
 				</p>
-				{/* <div className="has-text-centered" style="margin-top:3rem;">
-				<b-button to="/register" type="is-primary" tag="nuxt-link" style="width:50%;">
-					寄付ページへ
-				</b-button>
-			</div> */}
+				<div className="has-text-centered">
+					<button className={`button is-primary ${styles.button}`}>
+						<Link href="/register">寄付ページへ</Link>
+					</button>
+				</div>
 			</div>
 		</>
 	);

--- a/pages/mypage.tsx
+++ b/pages/mypage.tsx
@@ -49,9 +49,9 @@ const MyPage: NextPage = () => {
 			<div className={styles.content}>
 				{isLogin ? (
 					<>
-						<h1 className="title pagetitle">マイページ</h1>
+						<h1 className="pagetitle">マイページ</h1>
 						<div className="card">
-							<h2 className="title">ユーザー情報</h2>
+							<h2 className={`title ${styles.title}`}>ユーザー情報</h2>
 							<button className={`button is-text ${styles.editButton}`} onClick={() => setIsEditUserModalOpen(true)}>
 								編集する
 							</button>
@@ -85,7 +85,7 @@ const MyPage: NextPage = () => {
 						</div>
 
 						<div className="card">
-							<h2 className="title">サブスクリプションの登録状況</h2>
+							<h2 className={`title ${styles.title}`}>サブスクリプションの登録状況</h2>
 							<div className="content">
 								<p className="has-text-primary has-text-weight-bold">ご利用中のプラン</p>
 								{subscriptions != null ? (
@@ -127,7 +127,7 @@ const MyPage: NextPage = () => {
 						</div>
 
 						<div className="card">
-							<h2 className="title">寄付の履歴</h2>
+							<h2 className={`title ${styles.title}`}>寄付の履歴</h2>
 							<div className="content">
 								{paymentHistory != null ? (
 									paymentHistory.length ? (

--- a/pages/mypage.tsx
+++ b/pages/mypage.tsx
@@ -64,7 +64,7 @@ const MyPage: NextPage = () => {
 							/>
 							<div className="content">
 								<p>
-									<a href="https://www.twinte.net/sponsor">寄附者一覧</a>
+									<a href="https://www.twinte.net/sponsor">寄付者一覧</a>
 									に表示するお名前とリンクです。
 								</p>
 								{currentUser ? (

--- a/pages/mypage.tsx
+++ b/pages/mypage.tsx
@@ -49,7 +49,7 @@ const MyPage: NextPage = () => {
 			<div className={styles.content}>
 				{isLogin ? (
 					<>
-						<h1 className="pagetitle">マイページ</h1>
+						<h1 className="title pagetitle">マイページ</h1>
 						<div className="card">
 							<h2 className={`title ${styles.title}`}>ユーザー情報</h2>
 							<button className={`button is-text ${styles.editButton}`} onClick={() => setIsEditUserModalOpen(true)}>

--- a/pages/mypage.tsx
+++ b/pages/mypage.tsx
@@ -47,9 +47,9 @@ const MyPage: NextPage = () => {
 		<>
 			<NextSeo title="マイページ" />
 			<div className={styles.content}>
+				<h1 className="title pagetitle">マイページ</h1>
 				{isLogin ? (
 					<>
-						<h1 className="title pagetitle">マイページ</h1>
 						<div className="card">
 							<h2 className={`title ${styles.title}`}>ユーザー情報</h2>
 							<button className={`button is-text ${styles.editButton}`} onClick={() => setIsEditUserModalOpen(true)}>
@@ -165,7 +165,9 @@ const MyPage: NextPage = () => {
 						</div>
 					</>
 				) : (
-					<p>右上のログインボタンからログインしてください。</p>
+					<p>
+						右上の「<span className="has-text-weight-bold">ログイン</span>」ボタンからログインしてください。
+					</p>
 				)}
 			</div>
 		</>

--- a/styles/components/Layout.module.scss
+++ b/styles/components/Layout.module.scss
@@ -1,4 +1,0 @@
-.footer {
-    text-align: right;
-    margin-top: 2rem;
-}

--- a/styles/components/Sidebar.module.scss
+++ b/styles/components/Sidebar.module.scss
@@ -2,7 +2,7 @@
 
 .sidebar {
     height: 100vh;
-    max-width: 250px;
+    width: 200px;
     min-height: 100%;
     padding: 0 1rem;
     background-color: $menu-color;
@@ -13,7 +13,7 @@
     }
 
     .logo {
-        max-width: 200px;
+        width: 160px;
         padding: 1rem 0.5rem;
     }
 

--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -50,25 +50,20 @@ $colors: ("white": ($white,
   font-size: 23px;
   line-height: 28px;
   margin-bottom: 1rem;
-  border-left: 5px solid $primary;
-  padding-left: 1rem;
 }
 
-.title.pagetitle {
-  border: initial;
-  padding-left: 0;
-}
-
-.title.pagetitle:before {
-  content: "";
-  background-image: url("/images/twinte-logo-color.png");
-  background-repeat: no-repeat;
-  display: inline-block;
-  height: 1.5em;
-  width: 1.5em;
-  background-size: contain;
-  vertical-align: middle;
-  margin-right: 8px;
+.pagetitle {
+  &:before {
+    content: "";
+    background-image: url("/images/twinte-logo-color.png");
+    background-repeat: no-repeat;
+    display: inline-block;
+    height: 1.5em;
+    width: 1.5em;
+    background-size: contain;
+    vertical-align: middle;
+    margin-right: 8px;
+  }
 }
 
 // カードを使いやすいように再定義

--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -68,6 +68,7 @@ $colors: ("white": ($white,
   width: 1.5em;
   background-size: contain;
   vertical-align: middle;
+  margin-right: 8px;
 }
 
 // カードを使いやすいように再定義

--- a/styles/pages/Home.module.scss
+++ b/styles/pages/Home.module.scss
@@ -9,4 +9,13 @@
       }
     }
   }
+
+  .button {
+    width: 50%;
+    margin-top: 3rem;
+
+    a {
+      color: #ffffff;
+    }
+  }
 }

--- a/styles/pages/MyPage.module.scss
+++ b/styles/pages/MyPage.module.scss
@@ -1,8 +1,15 @@
+@import "../variables.scss";
+
 .content {
     .editButton {
         position: absolute;
         top: 2rem;
         right: 2rem;
         text-decoration: none
+    }
+
+    .title {
+        border-left: 5px solid $primary;
+        padding-left: 1rem;
     }
 }


### PR DESCRIPTION
https://github.com/twin-te/twinte-sponsorship/issues/26 を見直している

- [x] topページ 最下部のボタンの実装忘れ
- [x] {寄付 | 寄附} の表記ゆれ -> 寄付に統一
- [x] ページタイトルとロゴの間を空ける
- [x] マイページ内のカードタイトルのみに  `border-left` をつける
- [x] サイドバーの横幅を固定
- [x] ドロワーの幅修正
- [x] 未ログイン時のマイページをfigmaに合わせる
- [x] vercel logoの位置を修正(モバイル版で中央に来るように)
- [x] `Layout.tsx` に `next-seo` を導入したときの `next/head` の削除漏れがあったので消した