### PR TITLE
現在の残高を表記

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -5,6 +5,10 @@ import Image from 'next/image';
 import { NextSeo } from 'next-seo';
 import Link from 'next/link';
 
+const BALANCE = 110735;
+const MONTHLY_COST = 10000;
+const LAST_UPDATE = '2024年4月21日';
+
 const Home: NextPage = () => {
 	return (
 		<>
@@ -15,13 +19,19 @@ const Home: NextPage = () => {
 
 				<p>
 					いつもTwin:teをご利用いただきありがとうございます。
-					Twin:teはおかげさまで2022年2月で3周年を迎え、筑波大学生の過半数に利用していただいている状況となりました。
+					Twin:teはおかげさまで2024年2月で5周年を迎え、筑波大学生の大半の方々に利用していただいている状況となりました。
 				</p>
 				<p>
 					当初よりTwin:teは「<span className="has-text-weight-bold">広告なしで無料の筑波大学生専用時間割アプリ</span>
 					」という構想で開発していますが、 Twin:teの運用にはどうしても資金が必要です。
 				</p>
 				<p>当初と比較してユーザー数が増え、それに伴って運営に必要な資金も増えています。</p>
+				<div className={styles.finance}>
+					現在の残高は<span className={styles.balance}>{BALANCE}</span>円です。これはTwin:teの運営費
+					<span className={styles.lifetime}>{(BALANCE / MONTHLY_COST).toFixed(1)}</span>ヶ月分に相当します。
+					<br />
+					<span className={styles.lastUpdate}>（{LAST_UPDATE}現在）</span>
+				</div>
 				<div className="has-text-centered">
 					<Image src={TwinteCost} alt="Twin:te_Cost" />
 				</div>

--- a/styles/pages/Home.module.scss
+++ b/styles/pages/Home.module.scss
@@ -19,3 +19,21 @@
     }
   }
 }
+
+.finance{
+  .balance {
+    font-size: 2rem;
+    font-weight: bold;
+    margin: 0 0.2rem;
+  } 
+
+  .lifetime {
+    font-size: 2rem;
+    font-weight: bold;
+    margin: 0 0.2rem;
+  } 
+
+  .lastUpdate {
+    font-size: 0.8rem;
+  }
+}


### PR DESCRIPTION
## 背景

現在 Twin:te がどれぐらいお金に困っているかが伝わりにくいという問題がある。

## 変更点

- 現在の Twin:te の残高と運営期間換算を表記するようにしました。
![image](https://github.com/twin-te/twinte-sponsorship/assets/45098934/cfa45809-5c2e-4952-88e7-9f914b22f80f)
本当はいい感じに口座の残高情報と結びつけたいのですが、取り急ぎハードコードしています。

- 一部表記が古かったので修正
